### PR TITLE
Fix debug.msg offset

### DIFF
--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -3,7 +3,7 @@
 
 - name: Enter "Check process" stage
   debug:
-  msg: '==> Check process ...'
+    msg: '==> Check process ...'
 
 # Nginx
 - name: Check nginx process
@@ -43,7 +43,7 @@
 
 - name: Enter "Smoke Test" stage
   debug:
-  msg: '==> Smoke test ...'
+    msg: '==> Smoke test ...'
 
 - name: install some packages for test
   become: true


### PR DESCRIPTION
Currently ansible fails with:

    ERROR! 'msg' is not a valid attribute for a Task

This PR is fixing it.